### PR TITLE
Say bonjour

### DIFF
--- a/database/migrations/2025_01_15_000001_add_area_unit_and_payment_percentages_to_sites_table.php
+++ b/database/migrations/2025_01_15_000001_add_area_unit_and_payment_percentages_to_sites_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sites', function (Blueprint $table) {
+            // Ajouter l'unité de mesure
+            $table->enum('area_unit', ['m2', 'hectare', 'are', 'centiare'])
+                  ->default('m2')
+                  ->after('total_area');
+            
+            // Ajouter la date de lancement
+            $table->date('launch_date')->nullable()->after('total_lots');
+            
+            // Ajouter les pourcentages personnalisés pour les plans de paiement
+            $table->decimal('percentage_1_year', 5, 2)->nullable()->after('enable_payment_1_year');
+            $table->decimal('percentage_2_years', 5, 2)->nullable()->after('enable_payment_2_years');
+            $table->decimal('percentage_3_years', 5, 2)->nullable()->after('enable_payment_3_years');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sites', function (Blueprint $table) {
+            $table->dropColumn([
+                'area_unit',
+                'launch_date',
+                'percentage_1_year',
+                'percentage_2_years',
+                'percentage_3_years'
+            ]);
+        });
+    }
+};

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -255,7 +255,13 @@
                                         <div class="flex-grow-1">
                                             <h6 class="text-secondary-brown mb-1">Terrains Vendus</h6>
                                             <h3 class="counter text-primary-orange mb-0">{{ $stats['sold_lots'] }}</h3>
-                                            <small class="text-muted">Total global</small>
+                                            <small class="text-muted">
+                                                @if(request('period') || request('year') || request('site_id') || request('commercial_id'))
+                                                    Selon filtres appliqués
+                                                @else
+                                                    Total global
+                                                @endif
+                                            </small>
                                         </div>
                                         <div class="text-primary-orange">
                                             <i class="fas fa-map-marked-alt fa-2x"></i>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -152,11 +152,12 @@
                     <div class="card card-orange shadow">
                         <div class="card-header bg-light-orange text-white">
                             <h5 class="mb-0"><i class="fas fa-filter me-2"></i>Filtres du Dashboard
-                            @if(config('app.debug') && (request()->has('site_id') || request()->has('commercial_id') || request()->has('period')))
+                            @if(config('app.debug') && (request()->has('site_id') || request()->has('commercial_id') || request()->has('period') || request()->has('year')))
                                 <small class="ms-2">[Filtres actifs: 
                                 @if(request('site_id')) Site: {{ request('site_id') }} @endif
                                 @if(request('commercial_id')) Commercial: {{ request('commercial_id') }} @endif
-                                @if(request('period')) Période: {{ request('period') }} @endif
+                                @if(request('period')) Mois: {{ ucfirst(request('period')) }} @endif
+                                @if(request('year')) Année: {{ request('year') }} @endif
                                 ]</small>
                             @endif
                             </h5>
@@ -165,7 +166,7 @@
                             <form method="GET" action="{{ route('dashboard') }}">
                                 <div class="row g-3">
                                     @if(auth()->user()->isAdmin() || auth()->user()->isManager())
-                                        <div class="col-md-3">
+                                        <div class="col-lg-3 col-md-6">
                                             <label for="site_filter" class="form-label text-secondary-brown">Site</label>
                                             <select name="site_id" id="site_filter" class="form-select">
                                                 <option value="">Tous les sites</option>
@@ -177,7 +178,7 @@
                                             </select>
                                         </div>
                                         
-                                        <div class="col-md-3">
+                                        <div class="col-lg-3 col-md-6">
                                             <label for="commercial_filter" class="form-label text-secondary-brown">Commercial</label>
                                             <select name="commercial_id" id="commercial_filter" class="form-select">
                                                 <option value="">Tous les commerciaux</option>
@@ -190,23 +191,49 @@
                                         </div>
                                     @endif
                                     
-                                    <div class="col-md-3">
-                                        <label for="period_filter" class="form-label text-secondary-brown">Période</label>
+                                    <div class="col-lg-3 col-md-6">
+                                        <label for="period_filter" class="form-label text-secondary-brown">Mois</label>
                                         <select name="period" id="period_filter" class="form-select">
-                                            <option value="today" {{ request('period') == 'today' ? 'selected' : '' }}>Aujourd'hui</option>
-                                            <option value="this_week" {{ request('period') == 'this_week' ? 'selected' : '' }}>Cette semaine</option>
-                                            <option value="this_month" {{ request('period', 'this_month') == 'this_month' ? 'selected' : '' }}>Ce mois</option>
-                                            <option value="last_month" {{ request('period') == 'last_month' ? 'selected' : '' }}>Mois dernier</option>
-                                            <option value="this_year" {{ request('period') == 'this_year' ? 'selected' : '' }}>Cette année</option>
+                                            <option value="">Tous les mois</option>
+                                            <option value="january" {{ request('period') == 'january' ? 'selected' : '' }}>Janvier</option>
+                                            <option value="february" {{ request('period') == 'february' ? 'selected' : '' }}>Février</option>
+                                            <option value="march" {{ request('period') == 'march' ? 'selected' : '' }}>Mars</option>
+                                            <option value="april" {{ request('period') == 'april' ? 'selected' : '' }}>Avril</option>
+                                            <option value="may" {{ request('period') == 'may' ? 'selected' : '' }}>Mai</option>
+                                            <option value="june" {{ request('period') == 'june' ? 'selected' : '' }}>Juin</option>
+                                            <option value="july" {{ request('period') == 'july' ? 'selected' : '' }}>Juillet</option>
+                                            <option value="august" {{ request('period') == 'august' ? 'selected' : '' }}>Août</option>
+                                            <option value="september" {{ request('period') == 'september' ? 'selected' : '' }}>Septembre</option>
+                                            <option value="october" {{ request('period') == 'october' ? 'selected' : '' }}>Octobre</option>
+                                            <option value="november" {{ request('period') == 'november' ? 'selected' : '' }}>Novembre</option>
+                                            <option value="december" {{ request('period') == 'december' ? 'selected' : '' }}>Décembre</option>
                                         </select>
                                     </div>
                                     
-                                    <div class="col-md-3 d-flex align-items-end">
+                                    <div class="col-lg-3 col-md-6">
+                                        <label for="year_filter" class="form-label text-secondary-brown">Année</label>
+                                        <select name="year" id="year_filter" class="form-select">
+                                            @php
+                                                $currentYear = date('Y');
+                                                $startYear = $currentYear - 2; // 2 ans en arrière
+                                                $endYear = $currentYear + 1;   // 1 an en avant
+                                            @endphp
+                                            <option value="">Toutes les années</option>
+                                            @for($year = $endYear; $year >= $startYear; $year--)
+                                                <option value="{{ $year }}" {{ request('year', $currentYear) == $year ? 'selected' : '' }}>{{ $year }}</option>
+                                            @endfor
+                                        </select>
+                                    </div>
+                                </div>
+                                
+                                <!-- Boutons sur une nouvelle ligne -->
+                                <div class="row mt-3">
+                                    <div class="col-12 d-flex justify-content-end">
                                         <button type="submit" class="btn btn-orange me-2">
-                                            <i class="fas fa-filter me-1"></i>Appliquer
+                                            <i class="fas fa-filter me-1"></i>Appliquer les filtres
                                         </button>
                                         <a href="{{ route('dashboard') }}" class="btn btn-outline-secondary">
-                                            <i class="fas fa-redo me-1"></i>Reset
+                                            <i class="fas fa-redo me-1"></i>Réinitialiser
                                         </a>
                                     </div>
                                 </div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -151,7 +151,15 @@
                 <div class="col-12">
                     <div class="card card-orange shadow">
                         <div class="card-header bg-light-orange text-white">
-                            <h5 class="mb-0"><i class="fas fa-filter me-2"></i>Filtres du Dashboard</h5>
+                            <h5 class="mb-0"><i class="fas fa-filter me-2"></i>Filtres du Dashboard
+                            @if(config('app.debug') && (request()->has('site_id') || request()->has('commercial_id') || request()->has('period')))
+                                <small class="ms-2">[Filtres actifs: 
+                                @if(request('site_id')) Site: {{ request('site_id') }} @endif
+                                @if(request('commercial_id')) Commercial: {{ request('commercial_id') }} @endif
+                                @if(request('period')) Période: {{ request('period') }} @endif
+                                ]</small>
+                            @endif
+                            </h5>
                         </div>
                         <div class="card-body">
                             <form method="GET" action="{{ route('dashboard') }}">
@@ -198,7 +206,7 @@
                                             <i class="fas fa-filter me-1"></i>Appliquer
                                         </button>
                                         <a href="{{ route('dashboard') }}" class="btn btn-outline-secondary">
-                                            <i class="fas fa-refresh me-1"></i>Reset
+                                            <i class="fas fa-redo me-1"></i>Reset
                                         </a>
                                     </div>
                                 </div>

--- a/resources/views/sites/create.blade.php
+++ b/resources/views/sites/create.blade.php
@@ -53,16 +53,34 @@
                             @enderror
                         </div>
                         
-                        <div class="col-md-4">
-                            <label class="form-label">Superficie totale (m²)</label>
+                        <div class="col-md-3">
+                            <label class="form-label">Superficie totale *</label>
                             <input type="number" class="form-control @error('total_area') is-invalid @enderror" 
-                                   name="total_area" value="{{ old('total_area') }}" step="0.01" min="0">
+                                   name="total_area" value="{{ old('total_area') }}" step="0.01" min="0" required>
                             @error('total_area')
                                 <div class="invalid-feedback">{{ $message }}</div>
                             @enderror
                         </div>
                         
-                        <div class="col-md-4">
+                        <div class="col-md-3">
+                            <label class="form-label">Unité de mesure *</label>
+                            <select class="form-select @error('area_unit') is-invalid @enderror" name="area_unit" required>
+                                <option value="">Choisir l'unité</option>
+                                <option value="m2" {{ old('area_unit') == 'm2' ? 'selected' : '' }}>Mètre carré (m²)</option>
+                                <option value="hectare" {{ old('area_unit') == 'hectare' ? 'selected' : '' }}>Hectare (ha)</option>
+                                <option value="are" {{ old('area_unit') == 'are' ? 'selected' : '' }}>Are (a)</option>
+                                <option value="centiare" {{ old('area_unit') == 'centiare' ? 'selected' : '' }}>Centiare (ca)</option>
+                            </select>
+                            @error('area_unit')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                            <small class="text-muted">
+                                <div>1 ha = 100 ares = 10 000 m²</div>
+                                <div>1 are = 100 centiares = 100 m²</div>
+                            </small>
+                        </div>
+                        
+                        <div class="col-md-3">
                             <label class="form-label">Nombre total de lots *</label>
                             <input type="number" class="form-control @error('total_lots') is-invalid @enderror" 
                                    name="total_lots" value="{{ old('total_lots') }}" required min="1">
@@ -71,7 +89,7 @@
                             @enderror
                         </div>
                         
-                        <div class="col-md-4">
+                        <div class="col-md-3">
                             <label class="form-label">Date de lancement</label>
                             <input type="date" class="form-control @error('launch_date') is-invalid @enderror" 
                                    name="launch_date" value="{{ old('launch_date') }}">
@@ -211,57 +229,104 @@
                     <h5 class="mb-0"><i class="fas fa-credit-card me-2"></i>Options de paiement disponibles</h5>
                 </div>
                 <div class="card-body">
-                    <p class="text-muted mb-3">Sélectionnez les modes de paiement autorisés pour ce site.</p>
+                    <p class="text-muted mb-3">Sélectionnez les modes de paiement autorisés et définissez les pourcentages de majoration.</p>
 
-                    <div class="row g-3">
+                    <div class="row g-4">
+                        <!-- Paiement comptant -->
                         <div class="col-md-6">
-                            <!-- Paiement comptant -->
-                            <div class="form-check mb-3 p-3 border rounded">
-                                <input class="form-check-input" type="checkbox" id="chkCash" 
-                                       name="enable_payment_cash" {{ old('enable_payment_cash', true) ? 'checked' : '' }}>
-                                <label class="form-check-label fw-bold text-success" for="chkCash">
-                                    <i class="fas fa-money-bill-wave me-2"></i>Paiement comptant
-                                </label>
-                                <div class="small text-muted mt-1">Prix de base sans majoration</div>
-                            </div>
-
-                            <!-- Paiement 1 an -->
-                            <div class="form-check mb-3 p-3 border rounded">
-                                <input class="form-check-input" type="checkbox" id="chk1Year" 
-                                       name="enable_payment_1_year" {{ old('enable_payment_1_year', true) ? 'checked' : '' }}>
-                                <label class="form-check-label fw-bold text-primary" for="chk1Year">
-                                    <i class="fas fa-calendar-alt me-2"></i>Paiement sur 1 an (+5%)
-                                </label>
-                                <div class="small text-muted mt-1">Prix de base + 5% de majoration</div>
+                            <div class="card border-success">
+                                <div class="card-body">
+                                    <div class="form-check mb-3">
+                                        <input class="form-check-input" type="checkbox" id="chkCash" 
+                                               name="enable_payment_cash" {{ old('enable_payment_cash', true) ? 'checked' : '' }}>
+                                        <label class="form-check-label fw-bold text-success" for="chkCash">
+                                            <i class="fas fa-money-bill-wave me-2"></i>Paiement comptant
+                                        </label>
+                                    </div>
+                                    <div class="small text-muted">Prix de base sans majoration (0%)</div>
+                                </div>
                             </div>
                         </div>
 
+                        <!-- Paiement 1 an -->
                         <div class="col-md-6">
-                            <!-- Paiement 2 ans -->
-                            <div class="form-check mb-3 p-3 border rounded">
-                                <input class="form-check-input" type="checkbox" id="chk2Years" 
-                                       name="enable_payment_2_years" {{ old('enable_payment_2_years', true) ? 'checked' : '' }}>
-                                <label class="form-check-label fw-bold text-warning" for="chk2Years">
-                                    <i class="fas fa-calendar-alt me-2"></i>Paiement sur 2 ans (+10%)
-                                </label>
-                                <div class="small text-muted mt-1">Prix de base + 10% de majoration</div>
+                            <div class="card border-primary">
+                                <div class="card-body">
+                                    <div class="form-check mb-3">
+                                        <input class="form-check-input payment-checkbox" type="checkbox" id="chk1Year" 
+                                               name="enable_payment_1_year" {{ old('enable_payment_1_year', true) ? 'checked' : '' }}
+                                               data-target="percentage1Year">
+                                        <label class="form-check-label fw-bold text-primary" for="chk1Year">
+                                            <i class="fas fa-calendar-alt me-2"></i>Paiement sur 1 an
+                                        </label>
+                                    </div>
+                                    <div class="percentage-input" id="percentage1Year" style="{{ old('enable_payment_1_year', true) ? '' : 'display: none;' }}">
+                                        <label class="form-label small">Pourcentage de majoration (%)</label>
+                                        <input type="number" class="form-control form-control-sm @error('percentage_1_year') is-invalid @enderror" 
+                                               name="percentage_1_year" value="{{ old('percentage_1_year', 5) }}" 
+                                               min="0" max="100" step="0.1" placeholder="Ex: 5">
+                                        @error('percentage_1_year')
+                                            <div class="invalid-feedback">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+                                </div>
                             </div>
+                        </div>
 
-                            <!-- Paiement 3 ans -->
-                            <div class="form-check mb-3 p-3 border rounded">
-                                <input class="form-check-input" type="checkbox" id="chk3Years" 
-                                       name="enable_payment_3_years" {{ old('enable_payment_3_years') ? 'checked' : '' }}>
-                                <label class="form-check-label fw-bold text-danger" for="chk3Years">
-                                    <i class="fas fa-calendar-alt me-2"></i>Paiement sur 3 ans (+15%)
-                                </label>
-                                <div class="small text-muted mt-1">Prix de base + 15% de majoration</div>
+                        <!-- Paiement 2 ans -->
+                        <div class="col-md-6">
+                            <div class="card border-warning">
+                                <div class="card-body">
+                                    <div class="form-check mb-3">
+                                        <input class="form-check-input payment-checkbox" type="checkbox" id="chk2Years" 
+                                               name="enable_payment_2_years" {{ old('enable_payment_2_years', true) ? 'checked' : '' }}
+                                               data-target="percentage2Years">
+                                        <label class="form-check-label fw-bold text-warning" for="chk2Years">
+                                            <i class="fas fa-calendar-alt me-2"></i>Paiement sur 2 ans
+                                        </label>
+                                    </div>
+                                    <div class="percentage-input" id="percentage2Years" style="{{ old('enable_payment_2_years', true) ? '' : 'display: none;' }}">
+                                        <label class="form-label small">Pourcentage de majoration (%)</label>
+                                        <input type="number" class="form-control form-control-sm @error('percentage_2_years') is-invalid @enderror" 
+                                               name="percentage_2_years" value="{{ old('percentage_2_years', 10) }}" 
+                                               min="0" max="100" step="0.1" placeholder="Ex: 10">
+                                        @error('percentage_2_years')
+                                            <div class="invalid-feedback">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Paiement 3 ans -->
+                        <div class="col-md-6">
+                            <div class="card border-danger">
+                                <div class="card-body">
+                                    <div class="form-check mb-3">
+                                        <input class="form-check-input payment-checkbox" type="checkbox" id="chk3Years" 
+                                               name="enable_payment_3_years" {{ old('enable_payment_3_years') ? 'checked' : '' }}
+                                               data-target="percentage3Years">
+                                        <label class="form-check-label fw-bold text-danger" for="chk3Years">
+                                            <i class="fas fa-calendar-alt me-2"></i>Paiement sur 3 ans
+                                        </label>
+                                    </div>
+                                    <div class="percentage-input" id="percentage3Years" style="{{ old('enable_payment_3_years') ? '' : 'display: none;' }}">
+                                        <label class="form-label small">Pourcentage de majoration (%)</label>
+                                        <input type="number" class="form-control form-control-sm @error('percentage_3_years') is-invalid @enderror" 
+                                               name="percentage_3_years" value="{{ old('percentage_3_years', 15) }}" 
+                                               min="0" max="100" step="0.1" placeholder="Ex: 15">
+                                        @error('percentage_3_years')
+                                            <div class="invalid-feedback">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>
                     
-                    <div class="alert alert-info mt-3">
+                    <div class="alert alert-info mt-4">
                         <i class="fas fa-info-circle me-2"></i>
-                        <strong>Note :</strong> Les prix finaux des lots seront calculés automatiquement en appliquant les majorations selon le plan de paiement choisi par le client.
+                        <strong>Note :</strong> Les prix finaux des lots seront calculés automatiquement en appliquant les pourcentages de majoration selon le plan de paiement choisi par le client.
                     </div>
                 </div>
             </div>
@@ -281,4 +346,79 @@
             </div>
         </form>
     </div>
+
+    <!-- JavaScript pour gérer l'affichage des champs de pourcentage -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            // Gérer l'affichage des champs de pourcentage
+            const paymentCheckboxes = document.querySelectorAll('.payment-checkbox');
+            
+            paymentCheckboxes.forEach(function(checkbox) {
+                checkbox.addEventListener('change', function() {
+                    const targetId = this.getAttribute('data-target');
+                    const targetDiv = document.getElementById(targetId);
+                    
+                    if (this.checked) {
+                        targetDiv.style.display = 'block';
+                        // Rendre le champ de pourcentage requis
+                        const percentageInput = targetDiv.querySelector('input[type="number"]');
+                        if (percentageInput) {
+                            percentageInput.required = true;
+                        }
+                    } else {
+                        targetDiv.style.display = 'none';
+                        // Retirer l'obligation du champ
+                        const percentageInput = targetDiv.querySelector('input[type="number"]');
+                        if (percentageInput) {
+                            percentageInput.required = false;
+                            percentageInput.value = '';
+                        }
+                    }
+                });
+            });
+            
+            // Calculateur de superficie (conversion automatique)
+            const areaInput = document.querySelector('input[name="total_area"]');
+            const unitSelect = document.querySelector('select[name="area_unit"]');
+            
+            if (areaInput && unitSelect) {
+                function updateAreaDisplay() {
+                    const area = parseFloat(areaInput.value) || 0;
+                    const unit = unitSelect.value;
+                    
+                    if (area > 0 && unit) {
+                        let conversions = '';
+                        
+                        switch(unit) {
+                            case 'hectare':
+                                conversions = `≈ ${(area * 10000).toLocaleString()} m² | ${(area * 100).toLocaleString()} ares`;
+                                break;
+                            case 'are':
+                                conversions = `≈ ${(area * 100).toLocaleString()} m² | ${(area / 100).toFixed(2)} ha`;
+                                break;
+                            case 'centiare':
+                                conversions = `≈ ${area.toLocaleString()} m² | ${(area / 10000).toFixed(4)} ha`;
+                                break;
+                            case 'm2':
+                                conversions = `≈ ${(area / 10000).toFixed(4)} ha | ${(area / 100).toFixed(2)} ares`;
+                                break;
+                        }
+                        
+                        // Afficher la conversion
+                        let conversionDiv = document.getElementById('area-conversion');
+                        if (!conversionDiv) {
+                            conversionDiv = document.createElement('div');
+                            conversionDiv.id = 'area-conversion';
+                            conversionDiv.className = 'small text-info mt-1';
+                            unitSelect.parentNode.appendChild(conversionDiv);
+                        }
+                        conversionDiv.innerHTML = `<i class="fas fa-calculator me-1"></i>${conversions}`;
+                    }
+                }
+                
+                areaInput.addEventListener('input', updateAreaDisplay);
+                unitSelect.addEventListener('change', updateAreaDisplay);
+            }
+        });
+    </script>
 </x-app-layout>


### PR DESCRIPTION
Correct dashboard filter application and ensure accurate 'terrains vendu' count.

The 'terrains vendu' count was incorrect because the existing method applied date filters, leading to an undercount. A new `getTotalSoldLotsCount` method has been introduced to provide a global count, while `getSoldLotsCount` is now used for filtered statistics. Additionally, the filter parsing logic was improved, and a commercial filter was added.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a4e676f-6597-4bab-9138-c5924c62d7f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a4e676f-6597-4bab-9138-c5924c62d7f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

